### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/NER/MSRA/train2pkl.py
+++ b/NER/MSRA/train2pkl.py
@@ -1,4 +1,5 @@
 #coding:utf-8
+from __future__ import print_function
 import codecs
 import re
 import pandas as pd
@@ -88,8 +89,8 @@ for line in input_data.readlines():
             labels.append(linelabel)
             
 input_data.close()    
-print len(datas)
-print len(labels)
+print(len(datas))
+print(len(labels))
     
 from compiler.ast import flatten
 all_words = flatten(datas)
@@ -130,7 +131,7 @@ x_train,x_test, y_train, y_test = train_test_split(x, y, test_size=0.1, random_s
 x_train, x_valid, y_train, y_valid = train_test_split(x_train, y_train,  test_size=0.2, random_state=43)
 
 
-print 'Finished creating the data generator.'
+print('Finished creating the data generator.')
 import pickle
 import os
 with open('../dataMSRA.pkl', 'wb') as outp:
@@ -144,6 +145,6 @@ with open('../dataMSRA.pkl', 'wb') as outp:
 	pickle.dump(y_test, outp)
 	pickle.dump(x_valid, outp)
 	pickle.dump(y_valid, outp)
-print '** Finished saving the data.'
+print('** Finished saving the data.')
 
 

--- a/NER/boson/data_util.py
+++ b/NER/boson/data_util.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: UTF-8 -*-
 
+from __future__ import print_function
 import codecs
 import pandas as pd
 import numpy as np
@@ -31,8 +32,8 @@ def data2pkl():
             labels.append(linelabel)
 
     input_data.close()
-    print len(datas),tags
-    print len(labels)
+    print(len(datas),tags)
+    print(len(labels))
     from compiler.ast import flatten
     all_words = flatten(datas)
     sr_allwords = pd.Series(all_words)
@@ -49,7 +50,7 @@ def data2pkl():
     id2tag = pd.Series(tags, index=tag_ids)
 
     word2id["unknow"] = len(word2id)+1
-    print word2id
+    print(word2id)
     max_len = 60
     def X_padding(words):
         ids = list(word2id[words])
@@ -88,7 +89,7 @@ def data2pkl():
 	    pickle.dump(y_test, outp)
 	    pickle.dump(x_valid, outp)
 	    pickle.dump(y_valid, outp)
-    print '** Finished saving the data.'
+    print('** Finished saving the data.')
     
     
     

--- a/NER/renMinRiBao/data_renmin_word.py
+++ b/NER/renMinRiBao/data_renmin_word.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF-8 -*-
 
+from __future__ import print_function
 import codecs
 import re
 import pdb
@@ -87,8 +88,8 @@ def data2pkl():
             labels.append(linelabel)
 
     input_data.close()
-    print len(datas)
-    print len(labels)
+    print(len(datas))
+    print(len(labels))
     from compiler.ast import flatten
     all_words = flatten(datas)
     sr_allwords = pd.Series(all_words)
@@ -105,7 +106,7 @@ def data2pkl():
     id2tag = pd.Series(tags, index=tag_ids)
     word2id["unknow"]=len(word2id)+1
     id2word[len(word2id)]="unknow"
-    print tag2id
+    print(tag2id)
     max_len = 60
     def X_padding(words):
         ids = list(word2id[words])
@@ -144,7 +145,7 @@ def data2pkl():
 	    pickle.dump(y_test, outp)
 	    pickle.dump(x_valid, outp)
 	    pickle.dump(y_valid, outp)
-    print '** Finished saving the data.'
+    print('** Finished saving the data.')
     
 
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.